### PR TITLE
Add new data base on new docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,7 @@ Everything is reasonably tested and working. Feedback is welcomed! Lots of docs 
 My server doesn't have auth enabled, so I really have no idea if this works with a password. lemme know?
 
 A command line interface app that uses this library exists. Most of the testing is done with this app.
-Find it here: https://github.com/davidnewhall/SecSpyCLI
+Find it here: https://github.com/davidnewhall/SecSpyCLI - full of great examples on how to use this library.
+
+
+- Requires [SecuritySpy 4.2.10b7](https://www.bensoftware.com/securityspy/download-beta.html) or later.

--- a/cameras.go
+++ b/cameras.go
@@ -61,7 +61,9 @@ func (c *Camera) StreamVideo(ops *VidOps, length time.Duration, maxsize int64) (
 		Copy:    true,    // Always copy securityspy RTSP urls.
 	})
 	params := c.nakeRequestParams(ops)
-	params.Set("auth", c.server.authB64)
+	if c.server.authB64 != "" {
+		params.Set("auth", c.server.authB64)
+	}
 	params.Set("codec", "h264")
 	// This is kinda crude, but will handle 99%.
 	url := strings.Replace(c.server.baseURL, "http", "rtsp", 1) + "++stream"
@@ -83,7 +85,9 @@ func (c *Camera) SaveVideo(ops *VidOps, length time.Duration, maxsize int64, out
 		Copy:    true,    // Always copy securityspy RTSP urls.
 	})
 	params := c.nakeRequestParams(ops)
-	params.Set("auth", c.server.authB64)
+	if c.server.authB64 != "" {
+		params.Set("auth", c.server.authB64)
+	}
 	params.Set("codec", "h264")
 	// This is kinda crude, but will handle 99%.
 	url := strings.Replace(c.server.baseURL, "http", "rtsp", 1) + "++stream"
@@ -208,10 +212,10 @@ func (c *Camera) SetSchedule(mode CameraMode, schedule Schedule) error {
 }
 
 // SetScheduleOverride temporarily overrides a camera mode's current schedule.
-func (c *Camera) SetScheduleOverride(mode CameraMode, schedule Schedule) error {
+func (c *Camera) SetScheduleOverride(mode CameraMode, scheduleOverride ScheduleOverride) error {
 	params := make(url.Values)
 	params.Set("mode", string(mode))
-	params.Set("id", strconv.Itoa(schedule.ID))
+	params.Set("id", string(scheduleOverride))
 	return c.server.simpleReq("++ssSetOverride", params, c.Number)
 }
 

--- a/cameras.go
+++ b/cameras.go
@@ -207,7 +207,7 @@ func (c *Camera) SetSchedule(mode CameraMode, schedule Schedule) error {
 	return c.server.simpleReq("++ssSetSchedule", params, c.Number)
 }
 
-// SetScheduleOverride temporarily overrides a camera mode's primary schedule.
+// SetScheduleOverride temporarily overrides a camera mode's current schedule.
 func (c *Camera) SetScheduleOverride(mode CameraMode, schedule Schedule) error {
 	params := make(url.Values)
 	params.Set("mode", string(mode))

--- a/cameras_types.go
+++ b/cameras_types.go
@@ -19,8 +19,8 @@ type CameraArmMode rune
 
 // Arming is either 0 or 1.
 const (
-	CameraDisarm CameraArmMode = 0
-	CameraArm    CameraArmMode = 1
+	CameraDisarm CameraArmMode = iota
+	CameraArm
 )
 
 // VidOps are the options for a video that can be requested from SecuritySpy

--- a/cameras_types.go
+++ b/cameras_types.go
@@ -15,12 +15,12 @@ const (
 )
 
 // CameraArmMode locks arming to an integer of 0 or 1.
-type CameraArmMode int
+type CameraArmMode rune
 
 // Arming is either 0 or 1.
 const (
-	CameraDisarm CameraArmMode = iota
-	CameraArm
+	CameraDisarm CameraArmMode = 0
+	CameraArm    CameraArmMode = 1
 )
 
 // VidOps are the options for a video that can be requested from SecuritySpy
@@ -78,7 +78,7 @@ type Camera struct {
 	AudioNetwork        YesNoBool      `xml:"audio_network"`        // yes, yes, yes, yes, yes, ...
 	AudioDeviceName     string         `xml:"audio_devicename"`     // Another Camera
 	MDenabled           YesNoBool      `xml:"md_enabled"`           // yes, yes, yes, yes, yes, ...
-	MDsensitivity       int            `xml:"md_sensitivity"`       // 51, 50, 47, 50, 50, 50, 5...  - this got returned twice under different key names.
+	MDsensitivity       int            `xml:"md_sensitivity"`       // 51, 50, 47, 50, 50, 50, 5...
 	MDtriggerTimeX2     Duration       `xml:"md_triggertime_x2"`    // 2, 2, 1, 2, 2, 2, 2
 	MDcapture           YesNoBool      `xml:"md_capture"`           // yes, yes, yes, yes, yes, ...
 	MDcaptureFPS        float64        `xml:"md_capturefps"`        // 20, 20, 20, 20, 20, 20, 2...

--- a/files.go
+++ b/files.go
@@ -55,6 +55,7 @@ func (f *Files) GetFile(name string) (*File, error) {
 		return nil, ErrorInvalidName
 	}
 	camName := split[len(split)-1]
+	// Arbitrary date format we hope doesn't change.
 	when, err := time.Parse("01-02-2006", split[0])
 	if err != nil {
 		return nil, ErrorInvalidName

--- a/files.go
+++ b/files.go
@@ -17,19 +17,24 @@ import (
 
 /* Files interface methods follow. */
 
-// GetPhotos returns a list of links to captured images.
-func (f *Files) GetPhotos(cameraNums []int, from, to time.Time) ([]*File, error) {
-	return f.getFiles(cameraNums, from, to, "i", "")
+// GetImages returns a list of links to captured images.
+func (f *Files) GetImages(cameraNums []int, from, to time.Time) ([]*File, error) {
+	return f.getFiles(cameraNums, from, to, "imageFilesCheck", "")
 }
 
-// GetAll returns a list of links to captured videos and images.
+// GetAll returns a list of links to all captured videos and images.
 func (f *Files) GetAll(cameraNums []int, from, to time.Time) ([]*File, error) {
-	return f.getFiles(cameraNums, from, to, "b", "")
+	return f.getFiles(cameraNums, from, to, "ccFilesCheck&mcFilesCheck&imageFilesCheck", "")
 }
 
-// GetVideos returns a list of links to captured videos.
-func (f *Files) GetVideos(cameraNums []int, from, to time.Time) ([]*File, error) {
-	return f.getFiles(cameraNums, from, to, "m", "")
+// GetMCVideos returns a list of links to motion-captured videos.
+func (f *Files) GetMCVideos(cameraNums []int, from, to time.Time) ([]*File, error) {
+	return f.getFiles(cameraNums, from, to, "mcFilesCheck", "")
+}
+
+// GetCCVideos returns a list of links to continuous-captured videos.
+func (f *Files) GetCCVideos(cameraNums []int, from, to time.Time) ([]*File, error) {
+	return f.getFiles(cameraNums, from, to, "ccFilesCheck", "")
 }
 
 // GetFile returns a file based on the name. It makes a lot of assumptions about file paths.
@@ -50,15 +55,15 @@ func (f *Files) GetFile(name string) (*File, error) {
 		return nil, ErrorInvalidName
 	}
 	camName := split[len(split)-1]
-	if split = strings.Split(split[0], "-"); len(split) != 3 {
+	when, err := time.Parse("01-02-2006", split[0])
+	if err != nil {
 		return nil, ErrorInvalidName
 	}
-	pathDate := split[2] + "-" + split[0] + "-" + split[1]
 	if file.Camera = f.server.Cameras.ByName(camName); file.Camera == nil {
 		return nil, ErrorCAMMissing
 	}
 	file.CameraNum = file.Camera.Number
-	file.Link.HREF = "++getfile/" + strconv.Itoa(file.CameraNum) + "/" + pathDate + "/" + url.QueryEscape(name)
+	file.Link.HREF = "++getfilehb/" + strconv.Itoa(file.CameraNum) + "/" + when.Format(fileDateFormat) + "/" + url.QueryEscape(name)
 	return file, nil
 }
 
@@ -80,15 +85,19 @@ func (f *File) Save(path string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer func() {
+	size, err := io.Copy(newFile, body)
+	if err != nil {
 		_ = newFile.Close()
-	}()
-	return io.Copy(newFile, body)
+		return size, nil
+	}
+	return size, newFile.Close()
 }
 
 // Get opens a file from a SecuritySpy link and returns the http.Body io.ReadCloser.
 func (f *File) Get() (io.ReadCloser, error) {
-	resp, err := f.server.secReq(f.Link.HREF, make(url.Values), 10*time.Second)
+	// use high bandwidth (full size) file download.
+	uri := strings.Replace(f.Link.HREF, "++getfile", "++getfilehb", 1)
+	resp, err := f.server.secReq(uri, make(url.Values), 10*time.Second)
 	if err != nil {
 		return nil, err
 	}
@@ -98,10 +107,11 @@ func (f *File) Get() (io.ReadCloser, error) {
 /* INTERFACE HELPER METHODS FOLLOW */
 
 // getFiles is a helper function to do all the work for GetVideos, GetPhotos & GetAll.
-func (f *Files) getFiles(cameraNums []int, from, to time.Time, fileType, continuation string) ([]*File, error) {
+func (f *Files) getFiles(cameraNums []int, from, to time.Time, fileTypes, continuation string) ([]*File, error) {
 	var entries []*File
 	var feed fileFeed
-	params := makeFilesParams(cameraNums, from, to, fileType, continuation)
+	params := makeFilesParams(cameraNums, from, to, fileTypes, continuation)
+	params.Set("results", "1000")
 	if xmldata, err := f.server.secReqXML("++download", params); err != nil {
 		return nil, err
 	} else if err := xml.Unmarshal(xmldata, &feed); err != nil {
@@ -116,7 +126,7 @@ func (f *Files) getFiles(cameraNums []int, from, to time.Time, fileType, continu
 	}
 	// ++download automatically paginates. Follow the continuation.
 	if feed.Continuation != "" && feed.Continuation != "FFFFFFFFFFFFFFFF" {
-		moreFiles, err := f.getFiles(cameraNums, from, to, fileType, feed.Continuation)
+		moreFiles, err := f.getFiles(cameraNums, from, to, fileTypes, feed.Continuation)
 		if entries = append(entries, moreFiles...); err != nil {
 			// We got some files, but one of the pages returned an error.
 			return entries, err
@@ -126,11 +136,13 @@ func (f *Files) getFiles(cameraNums []int, from, to time.Time, fileType, continu
 }
 
 // makeFilesParams makes the url Values for a file retreival.
-func makeFilesParams(cameraNums []int, from time.Time, to time.Time, fileType string, continuation string) url.Values {
+func makeFilesParams(cameraNums []int, from time.Time, to time.Time, fileTypes string, continuation string) url.Values {
 	params := make(url.Values)
-	params.Set("date1Text", from.Format(fileDateFormat))
-	params.Set("date2Text", to.Format(fileDateFormat))
-	params.Set("fileTypeMenu", fileType)
+	params.Set("date1", from.Format(fileDateFormat))
+	params.Set("date2", to.Format(fileDateFormat))
+	for _, fileType := range strings.Split(fileTypes, "&") {
+		params.Set(fileType, "1")
+	}
 	for _, num := range cameraNums {
 		params.Add("cameraNum", strconv.Itoa(num))
 	}

--- a/files_types.go
+++ b/files_types.go
@@ -5,8 +5,14 @@ import (
 	"time"
 )
 
-// fileDateFormat is the format the SecuritySpy ++download method accepts.
-var fileDateFormat = "2006-01-02"
+// downloadDateFormat is the format the SecuritySpy ++download method accepts.
+// This matches the ++download inputs AND the folder names files are saved into.
+var downloadDateFormat = "2006-01-02"
+
+// Arbitrary date format used for saved files we hope doesn't change.
+// This is used in the actual name of files that are saved. No where else.
+// The GetFile() method uses this to construct arbitrary file download paths.
+var fileDateFormat = "01-02-2006"
 
 // Errors returned by this file.
 const (
@@ -28,7 +34,7 @@ type fileFeed struct {
 	Title        string   `xml:"title"`        // Downloads
 	GmtOffset    string   `xml:"gmt-offset"`   // -28800
 	Continuation string   `xml:"continuation"` // 0007E3010C0E1D3A
-	Entries      []*File  `xml:"entry"`
+	Entries      []*File  `xml:"entry"`        // List of File pointers
 }
 
 // File represents a saved media file.

--- a/files_types.go
+++ b/files_types.go
@@ -6,7 +6,7 @@ import (
 )
 
 // fileDateFormat is the format the SecuritySpy ++download method accepts.
-var fileDateFormat = "01/02/06"
+var fileDateFormat = "2006-01-02"
 
 // Errors returned by this file.
 const (

--- a/ptz.go
+++ b/ptz.go
@@ -45,7 +45,7 @@ func (z *PTZ) DownLeft() error {
 
 // UpRight sends a camera up and to the right. like it's 1999.
 func (z *PTZ) UpRight() error {
-	return z.ptzReq(ptzCommandRight)
+	return z.ptzReq(ptzCommandUpRight)
 }
 
 // DownRight is sorta like making the camera do a dab.
@@ -133,6 +133,6 @@ func (z *PTZ) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	z.HasHome = z.rawCaps&ptzHome == ptzHome
 	z.HasZoom = z.rawCaps&ptzZoom == ptzZoom
 	z.HasPresets = z.rawCaps&ptzPresets == ptzPresets
-	z.HasSpeed = z.rawCaps&ptzSpeed == ptzSpeed
+	z.Continuous = z.rawCaps&ptzContinuous == ptzContinuous
 	return nil
 }

--- a/ptz.go
+++ b/ptz.go
@@ -120,7 +120,7 @@ func (z *PTZ) Stop() error {
 func (z *PTZ) ptzReq(command ptzCommand) error {
 	params := make(url.Values)
 	params.Set("command", strconv.Itoa(int(command)))
-	return z.camera.simpleReq("++ptz/command", params)
+	return z.camera.server.simpleReq("++ptz/command", params, z.camera.Number)
 }
 
 // UnmarshalXML method converts ptzCapbilities bitmask into true/false abilities.

--- a/ptz_types.go
+++ b/ptz_types.go
@@ -2,17 +2,23 @@ package securityspy
 
 // PTZ are what "things" a camera can do.
 type PTZ struct {
-	camera     *Camera
+	camera  *Camera
+	rawCaps int
+	// HasPanTilt is true if a camera can pan and tilt using PTZ controls.
 	HasPanTilt bool
-	HasHome    bool
-	HasZoom    bool
+	// HasHome is true if the camera supports the home position PTZ command.
+	HasHome bool
+	// HasHome is true if the camera supports zooming in and out.
+	HasZoom bool
+	// HasPresets is true when the camera allows user-defined preset positions.
 	HasPresets bool
-	HasSpeed   bool // This is missing full documentation; may not be accurate.
-	rawCaps    int
+	// Continuous is true if the camera supports continuous movement. Most cameras
+	// now days support this. You will need to call Camera.Stop() to stop movement.
+	Continuous bool
 }
 
 // PTZpreset locks our poresets to a max of 8
-type PTZpreset int
+type PTZpreset rune
 
 // Presets are 1 through 8.
 const (
@@ -29,11 +35,11 @@ const (
 
 // Bitmask values for PTZ Capabilities.
 const (
-	ptzPanTilt int = 1 << iota // 1
-	ptzHome                    // 2
-	ptzZoom                    // 4
-	ptzPresets                 // 8
-	ptzSpeed                   // 16
+	ptzPanTilt    int = 1 << iota // 1
+	ptzHome                       // 2
+	ptzZoom                       // 4
+	ptzPresets                    // 8
+	ptzContinuous                 // 16
 )
 
 // ptzCommand are the possible PTZ commands.

--- a/schedules.go
+++ b/schedules.go
@@ -1,0 +1,28 @@
+package securityspy
+
+import (
+	"net/url"
+	"strconv"
+)
+
+/* There are no methods for updating or changing schedules through the API,
+   but you can assign already-existing schedules to cameras using the Camera
+   methods. There is one method for invoking a schedule preset.
+*/
+
+// Schedules returns a list of pre-existing schedules that can be assigned to cameras.
+func (s *Server) Schedules() []Schedule {
+	return s.systemInfo.ScheduleList.Schedules
+}
+
+// SchedulePresets provides a list of presets one can pass into SetSchedulePreset()
+func (s *Server) SchedulePresets() []Schedule {
+	return s.systemInfo.SchedulePresetList.SchedulePresets
+}
+
+// SetSchedulePreset configures the schedule preset for a camera mode.
+func (s *Server) SetSchedulePreset(schedule Schedule) error {
+	params := make(url.Values)
+	params.Set("id", strconv.Itoa(schedule.ID))
+	return s.simpleReq("++ssSetPreset", params, -1)
+}

--- a/schedules.go
+++ b/schedules.go
@@ -6,23 +6,34 @@ import (
 )
 
 /* There are no methods for updating or changing schedules through the API,
-   but you can assign already-existing schedules to cameras using the Camera
-   methods. There is one method for invoking a schedule preset.
+   but you can assign already-existing schedules to cameras using a Camera
+   method. You can also assign hard coded Schedule Overrides to cameras using
+	 a different method.
+
+	 There is one "schedule" method for invoking a system-wide schedule preset.
 */
 
-// Schedules returns a list of pre-existing schedules that can be assigned to cameras.
-func (s *Server) Schedules() []Schedule {
-	return s.systemInfo.ScheduleList.Schedules
-}
-
-// SchedulePresets provides a list of presets one can pass into SetSchedulePreset()
-func (s *Server) SchedulePresets() []Schedule {
-	return s.systemInfo.SchedulePresetList.SchedulePresets
-}
-
-// SetSchedulePreset configures the schedule preset for a camera mode.
-func (s *Server) SetSchedulePreset(schedule Schedule) error {
+// SetSchedulePreset invokes a schedule preset. This [may/will] affect all camera arm modes.
+// Find presets you can pass into this method at server.Info.SchedulePresets
+func (s *Server) SetSchedulePreset(schedule SchedulePreset) error {
 	params := make(url.Values)
 	params.Set("id", strconv.Itoa(schedule.ID))
 	return s.simpleReq("++ssSetPreset", params, -1)
+}
+
+// String provides a description of a Schedule Override.
+func (e ScheduleOverride) String() string {
+	switch e {
+	case ScheduleOverrideNone:
+		return "No Schedule Override"
+	case ScheduleOverrideUnarmedUntilEvent:
+		return "Unarmed Until Next Scheduled Event"
+	case ScheduleOverrideArmedUntilEvent:
+		return "Armed Until Next Scheduled Event"
+	case ScheduleOverrideUnarmedOneHour:
+		return "Unarmed For 1 Hour"
+	case ScheduleOverrideArmedOneHour:
+		return "Armed For 1 Hour"
+	}
+	return "Unknown Schedule Override"
 }

--- a/schedules_types.go
+++ b/schedules_types.go
@@ -1,15 +1,20 @@
 package securityspy
 
-/* There are no docuemnted methods for updating or changing schedules. */
+// CameraMode is a set of constants to deal with three specific camera modes.
+type CameraMode rune
 
-// schedule is for arming and disarming motion, capture, actions, etc.
-type schedule struct {
+// Camera modes used by Camera scheduling methods.
+const (
+	CameraModeAll        CameraMode = '*'
+	CameraModeMotion     CameraMode = 'M'
+	CameraModeActions    CameraMode = 'A'
+	CameraModeContinuous CameraMode = 'C'
+)
+
+// Schedule is for arming and disarming motion, capture, actions, etc.
+// This types holds the schedule's name and its id. Pass this type into
+// Camera schedule methods to set and re-assign schedules on camera parameters.
+type Schedule struct {
 	Name string `xml:"name"` // Unarmed 24/7, Armed 24/7,...
-	ID   int    `xml:"id"`   // 0, 1, 2, 3
-}
-
-// schedulePresets defines the presets for schedules returned from SecuritySpy
-type schedulePresets struct {
-	Name string `xml:"name"` // MySchedule, NowOnly, Weekends
 	ID   int    `xml:"id"`   // 0, 1, 2, 3
 }

--- a/schedules_types.go
+++ b/schedules_types.go
@@ -11,10 +11,27 @@ const (
 	CameraModeContinuous CameraMode = 'C'
 )
 
+// CameraMode is a set of constants to deal with three specific camera modes.
+// The String() method returns a description.
+type ScheduleOverride rune
+
+const (
+	ScheduleOverrideNone ScheduleOverride = iota
+	ScheduleOverrideUnarmedUntilEvent
+	ScheduleOverrideArmedUntilEvent
+	ScheduleOverrideUnarmedOneHour
+	ScheduleOverrideArmedOneHour
+)
+
 // Schedule is for arming and disarming motion, capture, actions, etc.
 // This types holds the schedule's name and its id. Pass this type into
 // Camera schedule methods to set and re-assign schedules on camera parameters.
 type Schedule struct {
+	Name string `xml:"name"` // Unarmed 24/7, Armed 24/7,...
+	ID   int    `xml:"id"`   // 0, 1, 2, 3
+}
+
+type SchedulePreset struct {
 	Name string `xml:"name"` // Unarmed 24/7, Armed 24/7,...
 	ID   int    `xml:"id"`   // 0, 1, 2, 3
 }

--- a/securityspy.go
+++ b/securityspy.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -49,35 +50,35 @@ func GetServer(user, pass, url string, verifySSL bool) (*Server, error) {
 }
 
 // Refresh gets fresh camera data from SecuritySpy, maybe run this after every action.
-func (c *Server) Refresh() error {
-	if xmldata, err := c.secReqXML("++systemInfo", nil); err != nil {
+func (s *Server) Refresh() error {
+	if xmldata, err := s.secReqXML("++systemInfo", nil); err != nil {
 		return err
-	} else if err := xml.Unmarshal(xmldata, c.systemInfo); err != nil {
+	} else if err := xml.Unmarshal(xmldata, s.systemInfo); err != nil {
 		return errors.Wrap(err, "xml.Unmarshal(++systemInfo)")
 	}
 
 	// Add the name to each assigned Camera Schedule.
-	for i, cam := range c.systemInfo.CameraList.Cameras {
-		c.systemInfo.CameraList.Cameras[i].ScheduleIDA.Name = strings.TrimSpace(c.getScheduleName(cam.ScheduleIDA.ID))
-		c.systemInfo.CameraList.Cameras[i].ScheduleIDCC.Name = strings.TrimSpace(c.getScheduleName(cam.ScheduleIDCC.ID))
-		c.systemInfo.CameraList.Cameras[i].ScheduleIDMC.Name = strings.TrimSpace(c.getScheduleName(cam.ScheduleIDMC.ID))
-		c.systemInfo.CameraList.Cameras[i].ScheduleOverrideA.Name = strings.TrimSpace(c.getScheduleName(cam.ScheduleOverrideA.ID))
-		c.systemInfo.CameraList.Cameras[i].ScheduleOverrideCC.Name = strings.TrimSpace(c.getScheduleName(cam.ScheduleOverrideCC.ID))
-		c.systemInfo.CameraList.Cameras[i].ScheduleOverrideMC.Name = strings.TrimSpace(c.getScheduleName(cam.ScheduleOverrideMC.ID))
-		c.Cameras.Names = append(c.Cameras.Names, cam.Name)
-		c.Cameras.Numbers = append(c.Cameras.Numbers, cam.Number)
+	for i, cam := range s.systemInfo.CameraList.Cameras {
+		s.systemInfo.CameraList.Cameras[i].ScheduleIDA.Name = strings.TrimSpace(s.getScheduleName(cam.ScheduleIDA.ID))
+		s.systemInfo.CameraList.Cameras[i].ScheduleIDCC.Name = strings.TrimSpace(s.getScheduleName(cam.ScheduleIDCC.ID))
+		s.systemInfo.CameraList.Cameras[i].ScheduleIDMC.Name = strings.TrimSpace(s.getScheduleName(cam.ScheduleIDMC.ID))
+		s.systemInfo.CameraList.Cameras[i].ScheduleOverrideA.Name = strings.TrimSpace(s.getScheduleName(cam.ScheduleOverrideA.ID))
+		s.systemInfo.CameraList.Cameras[i].ScheduleOverrideCC.Name = strings.TrimSpace(s.getScheduleName(cam.ScheduleOverrideCC.ID))
+		s.systemInfo.CameraList.Cameras[i].ScheduleOverrideMC.Name = strings.TrimSpace(s.getScheduleName(cam.ScheduleOverrideMC.ID))
+		s.Cameras.Names = append(s.Cameras.Names, cam.Name)
+		s.Cameras.Numbers = append(s.Cameras.Numbers, cam.Number)
 	}
-	c.systemInfo.Server.Refreshed = time.Now()
-	c.Cameras.Count = len(c.systemInfo.CameraList.Cameras)
+	s.systemInfo.Server.Refreshed = time.Now()
+	s.Cameras.Count = len(s.systemInfo.CameraList.Cameras)
 	return nil
 }
 
 // RefreshScripts refreshes the list of script files. Probably doesn't change much.
 // Retreivable as serverInfo.Scripts.Names
-func (c *Server) RefreshScripts() error {
-	if xmldata, err := c.secReqXML("++scripts", nil); err != nil {
+func (s *Server) RefreshScripts() error {
+	if xmldata, err := s.secReqXML("++scripts", nil); err != nil {
 		return err
-	} else if err := xml.Unmarshal(xmldata, &c.systemInfo.Server.Scripts); err != nil {
+	} else if err := xml.Unmarshal(xmldata, &s.systemInfo.Server.Scripts); err != nil {
 		return errors.Wrap(err, "xml.Unmarshal(++scripts)")
 	}
 	return nil
@@ -85,10 +86,10 @@ func (c *Server) RefreshScripts() error {
 
 // RefreshSounds refreshes the list of sound files. Probably doesn't change much.
 // Retreivable as serverInfo.Sounds.Names
-func (c *Server) RefreshSounds() error {
-	if xmldata, err := c.secReqXML("++sounds", nil); err != nil {
+func (s *Server) RefreshSounds() error {
+	if xmldata, err := s.secReqXML("++sounds", nil); err != nil {
 		return err
-	} else if err := xml.Unmarshal(xmldata, &c.systemInfo.Server.Sounds); err != nil {
+	} else if err := xml.Unmarshal(xmldata, &s.systemInfo.Server.Sounds); err != nil {
 		return errors.Wrap(err, "xml.Unmarshal(++sounds)")
 	}
 	return nil
@@ -97,16 +98,16 @@ func (c *Server) RefreshSounds() error {
 /* INTERFACE HELPER METHODS FOLLOW */
 
 // secReq is a helper function that formats the http request to SecuritySpy
-func (c *Server) secReq(apiPath string, params url.Values, timeout time.Duration) (resp *http.Response, err error) {
+func (s *Server) secReq(apiPath string, params url.Values, timeout time.Duration) (resp *http.Response, err error) {
 	if params == nil {
 		params = make(url.Values)
 	}
-	a := &http.Client{Timeout: timeout, Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: !c.verifySSL}}}
-	req, err := http.NewRequest("GET", c.baseURL+apiPath, nil)
+	a := &http.Client{Timeout: timeout, Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: !s.verifySSL}}}
+	req, err := http.NewRequest("GET", s.baseURL+apiPath, nil)
 	if err != nil {
 		return resp, errors.Wrap(err, "http.NewRequest()")
 	}
-	params.Set("auth", c.authB64)
+	params.Set("auth", s.authB64)
 	if a := apiPath; !strings.HasPrefix(a, "++getfile") && !strings.HasPrefix(a, "++event") &&
 		!strings.HasPrefix(a, "++image") && !strings.HasPrefix(a, "++audio") &&
 		!strings.HasPrefix(a, "++stream") && !strings.HasPrefix(a, "++video") {
@@ -122,8 +123,8 @@ func (c *Server) secReq(apiPath string, params url.Values, timeout time.Duration
 }
 
 // secReqXML returns raw http body, so it can be unmarshaled into an xml struct.
-func (c *Server) secReqXML(apiPath string, params url.Values) (body []byte, err error) {
-	resp, err := c.secReq(apiPath, params, 15*time.Second)
+func (s *Server) secReqXML(apiPath string, params url.Values) (body []byte, err error) {
+	resp, err := s.secReq(apiPath, params, 15*time.Second)
 	if err != nil {
 		return body, err
 	}
@@ -132,18 +133,38 @@ func (c *Server) secReqXML(apiPath string, params url.Values) (body []byte, err 
 	}()
 	if resp.StatusCode != http.StatusOK {
 		return body, errors.Errorf("request failed (%v): %v (status: %v/%v)",
-			c.username, c.baseURL+apiPath, resp.StatusCode, resp.Status)
+			s.username, s.baseURL+apiPath, resp.StatusCode, resp.Status)
 	} else if body, err = ioutil.ReadAll(resp.Body); err == nil {
 		return body, errors.Wrap(err, "ioutil.ReadAll(resp.Body)")
 	}
 	return body, nil
 }
 
-func (c *Server) getScheduleName(id int) string {
-	for _, schedule := range c.systemInfo.ScheduleList.Schedules {
+func (s *Server) getScheduleName(id int) string {
+	for _, schedule := range s.systemInfo.ScheduleList.Schedules {
 		if schedule.ID == id {
 			return schedule.Name
 		}
 	}
 	return "Unknown Schedule"
+}
+
+// simpleReq performes HTTP req, checks for OK at end of output.
+func (s *Server) simpleReq(apiURI string, params url.Values, cameraNum int) error {
+	if cameraNum != -1 {
+		params.Set("cameraNum", strconv.Itoa(cameraNum))
+	}
+	resp, err := s.secReq(apiURI, params, 10*time.Second)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if body, err := ioutil.ReadAll(resp.Body); err != nil {
+		return err
+	} else if !strings.HasSuffix(string(body), "OK") {
+		return ErrorCmdNotOK
+	}
+	return nil
 }

--- a/securityspy_types.go
+++ b/securityspy_types.go
@@ -15,7 +15,8 @@ func (e Error) Error() string {
 	return string(e)
 }
 
-// Server is the main interface.
+// Server is the main interface for this library.
+// Contains sub-interfaces for cameras, ptz, files & events
 type Server struct {
 	verifySSL  bool
 	baseURL    string
@@ -28,7 +29,7 @@ type Server struct {
 	Info       *ServerInfo
 }
 
-// ServerInfo represents all the SecuritySpy ServerInfo Info
+// ServerInfo represents all the SecuritySpy server's information.
 type ServerInfo struct {
 	Name             string    `xml:"name"`             // SecuritySpy
 	Version          string    `xml:"version"`          // 4.2.9
@@ -51,13 +52,10 @@ type ServerInfo struct {
 	DateFormat       string    `xml:"date-format"`
 	TimeFormat       string    `xml:"time-format"`
 	Refreshed        time.Time // updated by Refresh()
-	// These are shoehorned in.
-	Scripts struct {
-		Names []string `xml:"name"`
-	} `xml:"scripts"`
-	Sounds struct {
-		Names []string `xml:"name"`
-	} `xml:"sounds"`
+	ScriptsNames     []string
+	SoundsNames      []string
+	Schedules        []Schedule
+	SchedulePresets  []SchedulePreset
 }
 
 // systemInfo reresents ++systemInfo
@@ -67,12 +65,20 @@ type systemInfo struct {
 	CameraList struct {
 		Cameras []*Camera `xml:"camera"`
 	} `xml:"cameralist"`
+	// All of these sub-lists get copied into ServerInfo by Refresh()
 	ScheduleList struct {
 		Schedules []Schedule `xml:"schedule"`
 	} `xml:"schedulelist"`
 	SchedulePresetList struct {
-		SchedulePresets []Schedule `xml:"schedulepreset"`
+		SchedulePresets []SchedulePreset `xml:"schedulepreset"`
 	} `xml:"schedulepresetlist"`
+	// These are shoehorned in.
+	Scripts struct {
+		Names []string `xml:"name"`
+	} `xml:"scripts"`
+	Sounds struct {
+		Names []string `xml:"name"`
+	} `xml:"sounds"`
 }
 
 // YesNoBool is used to capture strings into boolean format.

--- a/securityspy_types.go
+++ b/securityspy_types.go
@@ -17,19 +17,19 @@ func (e Error) Error() string {
 
 // Server is the main interface.
 type Server struct {
-	systemInfo *systemInfo
 	verifySSL  bool
 	baseURL    string
 	authB64    string
 	username   string
+	systemInfo *systemInfo
 	Files      *Files
 	Events     *Events
 	Cameras    *Cameras
-	Info       *serverInfo
+	Info       *ServerInfo
 }
 
-// serverInfo represents all the SecuritySpy serverInfo Info
-type serverInfo struct {
+// ServerInfo represents all the SecuritySpy ServerInfo Info
+type ServerInfo struct {
 	Name             string    `xml:"name"`             // SecuritySpy
 	Version          string    `xml:"version"`          // 4.2.9
 	UUID             string    `xml:"uuid"`             // C03L1333F8J3AkXIZS1O
@@ -46,6 +46,10 @@ type serverInfo struct {
 	HTTPSEnabled     YesNoBool `xml:"https-enabled"`  // no
 	HTTPSPort        int       `xml:"https-port"`     // 8001
 	HTTPSPortWan     int       `xml:"https-port-wan"` // 8001
+	CurrentTime      time.Time `xml:"current-local-time"`
+	GmtOffset        int       `xml:"seconds-from-gmt"`
+	DateFormat       string    `xml:"date-format"`
+	TimeFormat       string    `xml:"time-format"`
 	Refreshed        time.Time // updated by Refresh()
 	// These are shoehorned in.
 	Scripts struct {
@@ -59,15 +63,15 @@ type serverInfo struct {
 // systemInfo reresents ++systemInfo
 type systemInfo struct {
 	XMLName    xml.Name   `xml:"system"`
-	Server     serverInfo `xml:"server"`
+	Server     ServerInfo `xml:"server"`
 	CameraList struct {
 		Cameras []*Camera `xml:"camera"`
 	} `xml:"cameralist"`
 	ScheduleList struct {
-		Schedules []schedule `xml:"schedule"`
+		Schedules []Schedule `xml:"schedule"`
 	} `xml:"schedulelist"`
 	SchedulePresetList struct {
-		SchedulePresets []schedulePresets `xml:"schedulepreset"`
+		SchedulePresets []Schedule `xml:"schedulepreset"`
 	} `xml:"schedulepresetlist"`
 }
 


### PR DESCRIPTION
- Converts some single-digit string constants to runes.
- Uses undocumented `file1`/`file2` parameters (with constant date format) for ++downloads.
- Replaced `Files` method `GetVideos` with `GetCCVideos` and `GetMCVideos`
- Add two new `Camera` methods: `SetSchedule` and `SetScheduleOverride`.
- Adds three new `Server` methods: `Schedules`, `SchedulePresets`, `SetSchedulePreset`.
The data returned from the Schedules method can be passed into the `SetSchedule` and `SetScheduleOverride` methods. The data from `SchedulePresets` method can be passed in `SetSchedulePreset`.

